### PR TITLE
add a readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-Rails app generated with [lewagon/rails-templates](https://github.com/lewagon/rails-templates), created by the [Le Wagon coding bootcamp](https://www.lewagon.com) team.
+# Rails ActionCable example
+
+This repo is used in support of the **WebSocket & ActionCable** lecture at [Le Wagon Web Dev bootcamp](https://www.lewagon.com/web-development-course/full-time).
+
+## Adding style
+
+To pickup the HTML / CSS you can have a look at [this commit](https://github.com/lewagon/rails-action-cable-chat/commit/d95e6ed4453d3fefcb2ae990e19bc4e191b15391).
+
+## Gemoji setup
+
+To add an emoji parser to the app, you can check [this commit](https://github.com/lewagon/rails-action-cable-chat/commit/257edfd40d733ae8702df2673c6dd3107cc33e77). 
+
+**N.B**: to import the images in the `public/images` folder, you need to run:
+
+```bash
+bundle exec gemoji extract public/images/emoji
+```
+
+as explained [here](https://www.rubydoc.info/gems/gemoji/3.0.1).


### PR DESCRIPTION
Adding a readme to document the frontend setup.

The result can be checked out here:

<img width="1372" alt="Screenshot 2020-02-19 at 12 09 51" src="https://user-images.githubusercontent.com/8090140/74840310-0fac4700-5327-11ea-8544-38f7d031d6d9.png">
<img width="1392" alt="Screenshot 2020-02-19 at 14 10 21" src="https://user-images.githubusercontent.com/8090140/74840320-15099180-5327-11ea-8645-a1d0a884d868.png">
