### PR TITLE
add multi-channel support

### DIFF
--- a/app/assets/stylesheets/components/_chatroom.scss
+++ b/app/assets/stylesheets/components/_chatroom.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  border-top: 1px solid $gray-200;
+  flex-grow: 1;
 
   h1 {
     padding: 0.5rem 1rem;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,3 +4,5 @@
 @import "chatroom";
 @import "message";
 @import "navbar";
+@import "sidenav";
+@import "utilities";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,6 +1,7 @@
 .navbar-lewagon {
   justify-content: space-between;
   background: white;
+  border-bottom: 1px solid $gray-200;
 }
 
 .navbar-lewagon .navbar-collapse {

--- a/app/assets/stylesheets/components/_sidenav.scss
+++ b/app/assets/stylesheets/components/_sidenav.scss
@@ -1,0 +1,11 @@
+.list-group-item {
+  border: none;
+  color: #2d2222;
+}
+
+.list-group-item.active {
+  background-color: #fff;
+  border-color: initial;
+  color: #2d2222;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/components/_utilities.scss
+++ b/app/assets/stylesheets/components/_utilities.scss
@@ -1,0 +1,7 @@
+.w-200px {
+  width: 200px;
+}
+
+.br-light {
+  border-right: 1px solid $gray-200;
+}

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -2,5 +2,6 @@ class ChatroomsController < ApplicationController
   def show
     @chatroom = Chatroom.find(params[:id])
     @message = Message.new
+    @chatrooms = Chatroom.all # NOTE(Eschults): for side navigation
   end
 end

--- a/app/javascript/channels/chatroom_channel.js
+++ b/app/javascript/channels/chatroom_channel.js
@@ -1,12 +1,14 @@
 import consumer from "./consumer";
 
-const messagesContainer = document.getElementById('messages');
-if (messagesContainer) {
-  const id = messagesContainer.dataset.chatroomId;
+document.addEventListener('turbolinks:load', () => {
+  const messagesContainer = document.getElementById('messages');
+  if (messagesContainer) {
+    const id = messagesContainer.dataset.chatroomId;
 
-  consumer.subscriptions.create({ channel: "ChatroomChannel", id: id }, {
-    received(data) {
-      messagesContainer.insertAdjacentHTML('beforeend', data); // called when data is broadcast in the cable
-    }
-  });
-}
+    consumer.subscriptions.create({ channel: "ChatroomChannel", id: id }, {
+      received(data) {
+        messagesContainer.insertAdjacentHTML('beforeend', data); // called when data is broadcast in the cable
+      }
+    });
+  }
+});

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex">
   <div class="list-group w-200px bg-white br-light">
-    <% Chatroom.all.each do |chatroom| %>
+    <% @chatrooms.each do |chatroom| %>
       <%= link_to "##{chatroom.name}", chatroom_path(chatroom), class: "list-group-item #{'active' if chatroom == @chatroom}" %>
     <% end %>
   </div>

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,15 +1,24 @@
-<div class="chatroom">
-  <h1>#<%= @chatroom.name %></h1>
+<div class="d-flex">
+  <div class="list-group w-200px bg-white br-light">
+    <% Chatroom.all.each do |chatroom| %>
+      <%= link_to "##{chatroom.name}", chatroom_path(chatroom), class: "list-group-item #{'active' if chatroom == @chatroom}" %>
+    <% end %>
+  </div>
 
-  <div>
-    <div id="messages" data-chatroom-id="<%= @chatroom.id %>">
-      <% @chatroom.messages.each do |message| %>
-        <%= render "messages/message", message: message %>
+
+  <div class="chatroom">
+    <h1>#<%= @chatroom.name %></h1>
+
+    <div>
+      <div id="messages" data-chatroom-id="<%= @chatroom.id %>">
+        <% @chatroom.messages.each do |message| %>
+          <%= render "messages/message", message: message %>
+        <% end %>
+      </div>
+
+      <%= simple_form_for [ @chatroom, @message ] do |f| %>
+        <%= f.input :content, label: false, placeholder: "Message ##{@chatroom.name}" %>
       <% end %>
     </div>
-
-    <%= simple_form_for [ @chatroom, @message ] do |f| %>
-      <%= f.input :content, label: false, placeholder: "Message ##{@chatroom.name}" %>
-    <% end %>
   </div>
 </div>


### PR DESCRIPTION
This adds multi-channel support:

<img width="1392" alt="Screenshot 2020-02-19 at 15 17 20" src="https://user-images.githubusercontent.com/8090140/74842620-fd340c80-532a-11ea-9a2f-b5350d984d9e.png">

⚠️@juliends @grmnlrt ⚠️in the lecture it's worth mentioning these two lines:
- [protect JS on other pages](https://github.com/lewagon/rails-action-cable-chat/blob/multi-channels/app/javascript/channels/chatroom_channel.js#L5)
- [enable navigation with turbolinks](https://github.com/lewagon/rails-action-cable-chat/blob/multi-channels/app/javascript/channels/chatroom_channel.js#L3)

I didn't update the lecture yet because I'm still hesitating about using [this Rails magic](https://github.com/lewagon/rails-action-cable-chat/blob/multi-channels/app/javascript/packs/application.js#L9) which loads every channel file by default. We want to converge towards Rails defaults, but we also want to give students 1 way of writing JavaScript and this doesn't follow our way (exporting a function and calling it in `application.js`).

P.S: let's leave this PR as a draft, that way `master` matches the lecture's code and this branch can be referred to when students want to go further.